### PR TITLE
Updated __init__.py to better handle default_fps

### DIFF
--- a/edl/__init__.py
+++ b/edl/__init__.py
@@ -532,12 +532,13 @@ class Parser(object):
     """No documentation for this class yet.
     """
 
-    default_fps = 25.0
+    default_fps = "25.0"
 
-    def __init__(self, fps):
+    def __init__(self, fps=None):
         if fps is None:
             self.fps = self.default_fps
-        self.fps = fps
+        else:
+            self.fps = fps
 
     def get_matchers(self):
         return [TitleMatcher(), EventMatcher(self.fps), EffectMatcher(),


### PR DESCRIPTION
Made default_fps value into a string (as required by the timecode library).
Added None as the default argument for fps in Parser.
Fixed **init** of Parser where fps was always set to the provided argument (including None).
